### PR TITLE
no longer mixing departures from ALGECEUT with CEUTALGE

### DIFF
--- a/backend/Controller/ferryController.js
+++ b/backend/Controller/ferryController.js
@@ -10,15 +10,12 @@ router.get("/departures", async (req, res) => {
     const today = new Date();
     const twoMonthsLater = new Date(today.setMonth(today.getMonth() + 2));
     const ALGECIRAS = "ALGECEUT";
-    const CEUTA = "CEUTALGE";
     const urlALG = `https://tadpole.clickferry.app/departures?route=${ALGECIRAS}&time=`;
-    const urlCEU = `https://tadpole.clickferry.app/departures?route=${CEUTA}&time=`;
     const dates = {};
     for (let d = new Date(); d <= twoMonthsLater; d.setDate(d.getDate() + 1)) {
       const date = d.toISOString().split("T")[0];
       const response1 = await axios.get(urlALG + date);
-      const response2 = await axios.get(urlCEU + date);
-      if (response1.data.length > 0 || response2.data.length > 0) {
+      if (response1.data.length > 0) {
         dates[date] = true;
       }
     }


### PR DESCRIPTION
Las salidas de Algeciras-Ceuta se juntaban con las de Ceuta-Algeciras, por lo que salían más salidas disponibles de las que realmente había. He borrado las de Ceuta - Algeciras porque realmente solo pedíamos que se hiciese con una de las rutas.